### PR TITLE
Added static and dynamic feedforward constants to the pivot

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
@@ -15,4 +15,12 @@ public class SlideConstants {
     public static double direction = 1;
     public static double tolerance = 0.5;
     public static double alertCurrent = 4;
+    /**
+     * Constant feedforward for the slides (probably don't need)
+     */
+    public static double FEEDFORWARD_STATIC = 0.0;
+    /**
+     * Feedforward value that is multiplied by <code>Math.cos(slideAngle)</code>
+     */
+    public static double FEEDFORWARD_DYNAMIC = 0.1;
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/CommandBaseTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/CommandBaseTest.java
@@ -25,7 +25,7 @@ public class CommandBaseTest extends CommandOpMode {
     @Override
     public void initialize(){
         pivotSubsystem = new PivotSubsystem(hardwareMap);
-        extend = new ExtensionSubsystem(hardwareMap);
+        extend = new ExtensionSubsystem(hardwareMap, pivotSubsystem);
         wrist = new WristSubsystem(hardwareMap);
         intake = new IntakeSubsystem(hardwareMap);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/ExtensionPIDTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/ExtensionPIDTest.java
@@ -7,23 +7,24 @@ import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 import org.firstinspires.ftc.teamcode.subsystems.ExtensionSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.Robot;
+
 @Config
 @TeleOp
-public class ExtensionPIDTest extends LinearOpMode {
+public class ExtensionPIDTest extends Robot {
     public static double targetInches = 0;
     @Override
     public void runOpMode() throws InterruptedException {
         telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
-        ExtensionSubsystem extensionSubsystem = new ExtensionSubsystem(hardwareMap);
         waitForStart();
         while (!isStopRequested()) {
-            extensionSubsystem.periodic();
-            extensionSubsystem.extendInches(targetInches);
+            extension.periodic();
+            extension.extendInches(targetInches);
 
-            telemetry.addData("current pos", extensionSubsystem.getCurrentPosition());
+            telemetry.addData("current pos", extension.getCurrentPosition());
             telemetry.addData("target", targetInches);
-            telemetry.addData("current inches", extensionSubsystem.getCurrentInches());
-            telemetry.addData("is there", extensionSubsystem.isClose(targetInches));
+            telemetry.addData("current inches", extension.getCurrentInches());
+            telemetry.addData("is there", extension.isClose(targetInches));
             telemetry.update();
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ExtensionSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ExtensionSubsystem.java
@@ -2,26 +2,26 @@ package org.firstinspires.ftc.teamcode.subsystems;
 
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.arcrobotics.ftclib.command.SubsystemBase;
-import com.arcrobotics.ftclib.controller.PIDController;
-import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.util.RobotLog;
 
 import org.firstinspires.ftc.robotcore.external.navigation.CurrentUnit;
+import org.firstinspires.ftc.teamcode.Constants.PivotConstants;
 import org.firstinspires.ftc.teamcode.Constants.SlideConstants;
+import org.firstinspires.ftc.teamcode.lib.AnalogEncoder;
 import org.firstinspires.ftc.teamcode.lib.SquIDController;
 import org.firstinspires.ftc.teamcode.lib.Util;
 
 public class ExtensionSubsystem extends SubsystemBase {
-    private DcMotorEx motor0, motor1;
+    private final DcMotorEx motor0, motor1;
     private int currentPos = 0;
-    private PIDController pid = new PIDController(SlideConstants.kP, SlideConstants.kI, SlideConstants.kD);
-    private SquIDController squid = new SquIDController();
+    private final SquIDController squid = new SquIDController();
     private double targetInches = 0;
     private boolean manualControl = true;
     private int resetOffset = 0;
+    private final AnalogEncoder slideRotationEncoder;
 
 
     public ExtensionSubsystem(HardwareMap hMap) {
@@ -31,27 +31,28 @@ public class ExtensionSubsystem extends SubsystemBase {
         motor1.setDirection(DcMotorSimple.Direction.REVERSE);
         motor0.setCurrentAlert(4, CurrentUnit.AMPS);
         motor1.setCurrentAlert(4, CurrentUnit.AMPS);
-
+        slideRotationEncoder = new AnalogEncoder("sensOrange", hMap);
+        slideRotationEncoder.setPositionOffset(PivotConstants.encoderOffset);
+        slideRotationEncoder.setInverted(PivotConstants.encoderInvert);
     }
+
     @Override
     public void periodic() {
         currentPos = -motor0.getCurrentPosition() - resetOffset;
         if (!manualControl) {
             extendInches(targetInches);
         }
-
     }
 
 
     /**
      *
-     *
      */
     public void setPower(double power) {
-        motor0.setPower(power*SlideConstants.direction);
-        motor1.setPower(-power*SlideConstants.direction);
-        if (getCurrentPosition()<10 && motor0.isOverCurrent()&&motor1.isOverCurrent() && power < 0) {
-            //resetOffset = getCurrentPosition();
+        motor0.setPower(power * SlideConstants.direction);
+        motor1.setPower(-power * SlideConstants.direction);
+        if (getCurrentPosition() < 10 && motor0.isOverCurrent() && motor1.isOverCurrent() && power < 0) {
+            // resetOffset = getCurrentPosition();
         }
         FtcDashboard.getInstance().getTelemetry().addData("manual control slides", manualControl);
         FtcDashboard.getInstance().getTelemetry().addData("slide motor power", power);
@@ -72,23 +73,25 @@ public class ExtensionSubsystem extends SubsystemBase {
     public void extendInches(double inches) {
         targetInches = inches;
         manualControl = false;
-        extendToPosition((int) (inches*SlideConstants.ticksPerInch));
+        extendToPosition((int) (inches * SlideConstants.ticksPerInch));
     }
+
     public void extendToPosition(int ticks) {
         squid.setPID(SlideConstants.kP);
 
-        double power = squid.calculate(ticks, getCurrentPosition());
+        double power =
+                + squid.calculate(ticks, getCurrentPosition())
+                + SlideConstants.FEEDFORWARD_STATIC
+                + SlideConstants.FEEDFORWARD_DYNAMIC * Math.cos(slideRotationEncoder.getRadians());
 
-        //power = 0;
-
-        if (ticks>=0 && !(getCurrentInches()<=0 && power<0) && !(getCurrentInches()>=SlideConstants.maxExtension)) {
+        if (ticks >= 0 && !(getCurrentInches() <= 0 && power < 0) && !(getCurrentInches() >= SlideConstants.maxExtension)) {
             setPower(power);
         }
-
     }
+
     /**
-    * @param target in inches, use the same one as the pid target
-    */
+     * @param target in inches, use the same one as the pid target
+     */
     public boolean isClose(double target) {
         return Util.inRange(target, getCurrentInches(), SlideConstants.tolerance);
     }
@@ -97,8 +100,9 @@ public class ExtensionSubsystem extends SubsystemBase {
     public int getCurrentPosition() {
         return currentPos;
     }
+
     public double getCurrentInches() {
-        return getCurrentPosition()/SlideConstants.ticksPerInch;
+        return getCurrentPosition() / SlideConstants.ticksPerInch;
     }
 
     public void stop() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ExtensionSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/ExtensionSubsystem.java
@@ -15,25 +15,25 @@ import org.firstinspires.ftc.teamcode.lib.SquIDController;
 import org.firstinspires.ftc.teamcode.lib.Util;
 
 public class ExtensionSubsystem extends SubsystemBase {
-    private final DcMotorEx motor0, motor1;
+    private final DcMotorEx motor0;
+    private final DcMotorEx motor1;
+    private final PivotSubsystem pivotSubsystem;
     private int currentPos = 0;
     private final SquIDController squid = new SquIDController();
     private double targetInches = 0;
     private boolean manualControl = true;
     private int resetOffset = 0;
-    private final AnalogEncoder slideRotationEncoder;
 
 
-    public ExtensionSubsystem(HardwareMap hMap) {
+    public ExtensionSubsystem(HardwareMap hMap, PivotSubsystem pivotSubsystem) {
+        this.pivotSubsystem = pivotSubsystem;
+
         motor0 = (DcMotorEx) hMap.dcMotor.get("slide0");
         motor0.setDirection(DcMotorSimple.Direction.REVERSE);
         motor1 = (DcMotorEx) hMap.dcMotor.get("slide1");
         motor1.setDirection(DcMotorSimple.Direction.REVERSE);
         motor0.setCurrentAlert(4, CurrentUnit.AMPS);
         motor1.setCurrentAlert(4, CurrentUnit.AMPS);
-        slideRotationEncoder = new AnalogEncoder("sensOrange", hMap);
-        slideRotationEncoder.setPositionOffset(PivotConstants.encoderOffset);
-        slideRotationEncoder.setInverted(PivotConstants.encoderInvert);
     }
 
     @Override
@@ -82,7 +82,7 @@ public class ExtensionSubsystem extends SubsystemBase {
         double power =
                 + squid.calculate(ticks, getCurrentPosition())
                 + SlideConstants.FEEDFORWARD_STATIC
-                + SlideConstants.FEEDFORWARD_DYNAMIC * Math.cos(slideRotationEncoder.getRadians());
+                + SlideConstants.FEEDFORWARD_DYNAMIC * Math.sin(pivotSubsystem.getCurrentPosition());
 
         if (ticks >= 0 && !(getCurrentInches() <= 0 && power < 0) && !(getCurrentInches() >= SlideConstants.maxExtension)) {
             setPower(power);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Robot.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/Robot.java
@@ -30,8 +30,8 @@ public abstract class Robot extends LinearOpMode {
         }
 
         mecanum = new MecanumDriveSubsystem("frontRight", "frontLeft", "backRight", "backLeft", hardwareMap, imu);
-        extension = new ExtensionSubsystem(hardwareMap);
         pivot = new PivotSubsystem(hardwareMap);
+        extension = new ExtensionSubsystem(hardwareMap, pivot);
         wrist = new WristSubsystem(hardwareMap);
         intake = new IntakeSubsystem(hardwareMap);
         imu = new IMULocalizer();


### PR DESCRIPTION
Maybe we should consider having a GlobalHardware class/singleton that holds stuff like the pivot encoders because it's being used in two places now

Sorry for the noise in the diff, I think I ran a format. I'll open a PR once this gets merged that formats the entire project