### PR TITLE
feat: Teleop Controls Rework

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/IntakeConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/IntakeConstants.java
@@ -15,7 +15,7 @@ public class IntakeConstants {
     public static double parkPos = 0.45;
     public static double bucketRetractPos = 0.05;
     public static double specimenReadyPos = 0.33;
-    public static double intakeReadyPos = 0.65;
+    public static double intakeReadyPos = 0.87;
 
     // wrist command constants
     public static double timeMultiplier = 0.3;
@@ -26,7 +26,7 @@ public class IntakeConstants {
     public static double closedPos = 0.75;
     public static double singleIntakePos = 0.7;
 
-    public static double clawOffset = 0.015;
+    public static double clawOffset = -0.16;
 
 
     // backtake

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/IntakeConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/IntakeConstants.java
@@ -15,6 +15,7 @@ public class IntakeConstants {
     public static double parkPos = 0.45;
     public static double bucketRetractPos = 0.05;
     public static double specimenReadyPos = 0.33;
+    public static double intakeReadyPos = 0.65;
 
     // wrist command constants
     public static double timeMultiplier = 0.3;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
@@ -15,6 +15,8 @@ public class SlideConstants {
     public static double bucketPos = 26.5;
     public static double lowBucketPos = 11.5;
 
+    public static double tiltInches = 15;
+
     public static double minExtension = 0;
     public static double direction = 1;
     public static double tolerance = 1;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Constants/SlideConstants.java
@@ -19,6 +19,11 @@ public class SlideConstants {
     public static double direction = 1;
     public static double tolerance = 1;
     public static double alertCurrent = 4;
+
+    /**
+     * The maximum extension, in inches, while pivoting down.
+     */
+    public static double maxPivotExtension = 25;
     /**
      * Constant feedforward for the slides (probably don't need)
      */

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/IntakeRetractCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/IntakeRetractCommand.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.arcrobotics.ftclib.command.Command;
 import com.arcrobotics.ftclib.command.ParallelCommandGroup;
 import com.arcrobotics.ftclib.command.SequentialCommandGroup;
+import com.arcrobotics.ftclib.command.WaitUntilCommand;
 
 import org.firstinspires.ftc.teamcode.Constants.IntakeConstants;
 import org.firstinspires.ftc.teamcode.Constants.PivotConstants;
@@ -25,7 +26,7 @@ public class IntakeRetractCommand extends SequentialCommandGroup {
         addCommands(
                 new WristCommand(wrist, IntakeConstants.foldedPos),
                 new ParallelCommandGroup(
-                        new PivotCommand(pivot, PivotConstants.retractDegrees),
+                        new WaitUntilCommand(() -> extend.getCurrentInches() < SlideConstants.tiltInches).andThen(new PivotCommand(pivot, PivotConstants.retractDegrees)),
                         new ExtendCommand(extend, SlideConstants.minExtension).withTimeout(extend.getReasonableExtensionMillis(0))
                 )
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosCommand.java
@@ -16,6 +16,9 @@ import org.firstinspires.ftc.teamcode.subsystems.ExtensionSubsystem;
 import org.firstinspires.ftc.teamcode.subsystems.IntakeSubsystem;
 import org.firstinspires.ftc.teamcode.subsystems.WristSubsystem;
 
+/**
+ * Flips the wrist down after a SubPosReadyCommand.
+ */
 public class SubPosCommand extends SequentialCommandGroup {
     ExtensionSubsystem extension;
 
@@ -27,11 +30,13 @@ public class SubPosCommand extends SequentialCommandGroup {
 
     public SubPosCommand(ExtensionSubsystem extension, WristSubsystem wrist, IntakeSubsystem intake) {
         addCommands(
-                new ExtendCommand(extension, 0)
-                        .withTimeout(extension.getReasonableExtensionMillis(0)),
+                //new ExtendCommand(extension, 0)
+                //        .withTimeout(extension.getReasonableExtensionMillis(0)),
                 new WristCommand(wrist, IntakeConstants.groundPos)
                         .alongWith(new IntakeControlCommand(intake, IntakeConstants.singleIntakePos, 1))
         );
+        // must require extension because manual control must use it, so this ensures any other commands using extension get interrupted
+        addRequirements(extension);
         this.extension = extension;
     }
 
@@ -41,6 +46,7 @@ public class SubPosCommand extends SequentialCommandGroup {
         Log.i("6", "Sub Pos Command, Interrupted: " + interrupted);
     }
 
+    @Deprecated
     public static Command newWithExtension(ExtensionSubsystem extension, WristSubsystem wrist, IntakeSubsystem intake, double inches) {
         return new SubPosCommand(extension,
                 new ExtendCommand(extension, inches)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosCommand.java
@@ -22,16 +22,8 @@ import org.firstinspires.ftc.teamcode.subsystems.WristSubsystem;
 public class SubPosCommand extends SequentialCommandGroup {
     ExtensionSubsystem extension;
 
-    private SubPosCommand(ExtensionSubsystem extension, Command... commands) {
-        super(commands);
-        this.extension = extension;
-
-    }
-
     public SubPosCommand(ExtensionSubsystem extension, WristSubsystem wrist, IntakeSubsystem intake) {
         addCommands(
-                //new ExtendCommand(extension, 0)
-                //        .withTimeout(extension.getReasonableExtensionMillis(0)),
                 new WristCommand(wrist, IntakeConstants.groundPos)
                         .alongWith(new IntakeControlCommand(intake, IntakeConstants.singleIntakePos, 1))
         );
@@ -44,15 +36,5 @@ public class SubPosCommand extends SequentialCommandGroup {
     public void end(boolean interrupted) {
         extension.setManualControl(true);
         Log.i("6", "Sub Pos Command, Interrupted: " + interrupted);
-    }
-
-    @Deprecated
-    public static Command newWithExtension(ExtensionSubsystem extension, WristSubsystem wrist, IntakeSubsystem intake, double inches) {
-        return new SubPosCommand(extension,
-                new ExtendCommand(extension, inches)
-                        .withTimeout(extension.getReasonableExtensionMillis(inches)),
-                new WristCommand(wrist, IntakeConstants.groundPos)
-                        .alongWith(new IntakeControlCommand(intake, IntakeConstants.singleIntakePos, 1))
-        );
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosReadyCommand.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/commands/group/SubPosReadyCommand.java
@@ -1,0 +1,48 @@
+package org.firstinspires.ftc.teamcode.commands.group;
+
+import com.arcrobotics.ftclib.command.ParallelCommandGroup;
+import com.arcrobotics.ftclib.command.SequentialCommandGroup;
+import com.arcrobotics.ftclib.command.WaitCommand;
+import com.arcrobotics.ftclib.command.WaitUntilCommand;
+
+import org.firstinspires.ftc.teamcode.Constants.IntakeConstants;
+import org.firstinspires.ftc.teamcode.Constants.PivotConstants;
+import org.firstinspires.ftc.teamcode.Constants.SlideConstants;
+import org.firstinspires.ftc.teamcode.commands.custom.ExtendCommand;
+import org.firstinspires.ftc.teamcode.commands.custom.IntakeControlCommand;
+import org.firstinspires.ftc.teamcode.commands.custom.PivotCommand;
+import org.firstinspires.ftc.teamcode.commands.custom.WristCommand;
+import org.firstinspires.ftc.teamcode.subsystems.ExtensionSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.IntakeSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.PivotSubsystem;
+import org.firstinspires.ftc.teamcode.subsystems.WristSubsystem;
+
+/**
+ * Command for extending slides out and half flipping claw down, but not yet fully bringing the claw down.
+ */
+public class SubPosReadyCommand extends SequentialCommandGroup {
+
+    public SubPosReadyCommand(ExtensionSubsystem extension, PivotSubsystem pivot, WristSubsystem wrist, IntakeSubsystem intake, double extendInches) {
+
+        // validate that this extension is within extension limit
+        assert extendInches < SlideConstants.submersibleIntakeMaxExtension;
+
+        addCommands(
+                new ParallelCommandGroup(
+                        // extend to the target
+                        new ExtendCommand(extension, extendInches).withTimeout(extension.getReasonableExtensionMillis(extendInches)),
+
+                        // wait until extension is below a certain threshold to stay within extension limit, then pivot to neutral
+                        new SequentialCommandGroup(
+                                new WaitUntilCommand(() -> extension.getCurrentInches() < SlideConstants.maxPivotExtension),
+                                new PivotCommand(pivot, PivotConstants.neutralPos)
+                        )
+
+                ),
+                // flip down wrist to a ready position
+                new WristCommand(wrist, IntakeConstants.intakeReadyPos)
+        );
+    }
+
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
@@ -38,6 +38,7 @@ import org.firstinspires.ftc.teamcode.commands.group.IntakeRetractCommand;
 import org.firstinspires.ftc.teamcode.commands.group.IntakeRetractReversedCommand;
 import org.firstinspires.ftc.teamcode.commands.group.RetractCommand;
 import org.firstinspires.ftc.teamcode.commands.group.SubPosCommand;
+import org.firstinspires.ftc.teamcode.commands.group.SubPosReadyCommand;
 import org.firstinspires.ftc.teamcode.commands.group.SubPosReversedCommand;
 import org.firstinspires.ftc.teamcode.lib.Util;
 import org.firstinspires.ftc.teamcode.subsystems.Robot;
@@ -244,21 +245,21 @@ public class TeleOpps extends Robot {
         // short
         operatorPad.getGamepadButton(GamepadKeys.Button.DPAD_LEFT).whenPressed(new ConditionalCommand(
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 7),
-                SubPosCommand.newWithExtension(extension, wrist, intake, 4),
+                new SubPosReadyCommand(extension, pivot, wrist, intake, 4),
                 reverseClaw::get
         ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
 
         // medium
         operatorPad.getGamepadButton(GamepadKeys.Button.DPAD_UP).whenPressed(new ConditionalCommand(
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 12),
-                SubPosCommand.newWithExtension(extension, wrist, intake, 7),
+                new SubPosReadyCommand(extension, pivot, wrist, intake, 10),
                 reverseClaw::get
         ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
 
         // lomg
         operatorPad.getGamepadButton(GamepadKeys.Button.DPAD_RIGHT).whenPressed(new ConditionalCommand(
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 15),
-                SubPosCommand.newWithExtension(extension, wrist, intake, 10),
+                new SubPosReadyCommand(extension, pivot, wrist, intake, 15),
                 reverseClaw::get
         ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
@@ -132,7 +132,12 @@ public class TeleOpps extends Robot {
         //        )
         //);
         // bucket pos
-        driverPad.getGamepadButton(GamepadKeys.Button.X).whenPressed(bucketPos());
+        new Trigger(() -> 
+                // if we have a sample and right trigger is pressed when out of intake
+                (getState() != FSMStates.INTAKE && intake.getDSensorSupplier() && gamepad1.right_trigger > 0.01)
+                        // or if X (square) is pressed
+                        || driverPad.wasJustPressed(GamepadKeys.Button.X))
+                .whileActiveOnce(bucketPos());
 
         // --------- INTAKE --------
         // backtake/fronttake toggles

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
@@ -132,7 +132,7 @@ public class TeleOpps extends Robot {
         //        )
         //);
         // bucket pos
-        new Trigger(() -> 
+        new Trigger(() ->
                 // if we have a sample and right trigger is pressed when out of intake
                 (getState() != FSMStates.INTAKE && intake.getDSensorSupplier() && gamepad1.right_trigger > 0.01)
                         // or if X (square) is pressed

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
@@ -9,6 +9,7 @@ import com.arcrobotics.ftclib.command.ConditionalCommand;
 import com.arcrobotics.ftclib.command.InstantCommand;
 import com.arcrobotics.ftclib.command.PerpetualCommand;
 import com.arcrobotics.ftclib.command.RunCommand;
+import com.arcrobotics.ftclib.command.ScheduleCommand;
 import com.arcrobotics.ftclib.command.SequentialCommandGroup;
 import com.arcrobotics.ftclib.command.WaitCommand;
 import com.arcrobotics.ftclib.command.WaitUntilCommand;
@@ -134,10 +135,10 @@ public class TeleOpps extends Robot {
         // bucket pos
         new Trigger(() ->
                 // if we have a sample and right trigger is pressed when out of intake
-                (getState() != FSMStates.INTAKE && intake.getDSensorSupplier() && gamepad1.right_trigger > 0.01)
-                        // or if X (square) is pressed
-                        || driverPad.wasJustPressed(GamepadKeys.Button.X))
-                .whileActiveOnce(bucketPos());
+                (getState() != FSMStates.INTAKE && intake.getDSensorSupplier() && gamepad1.right_trigger > 0.01))
+                .whileActiveOnce(new ScheduleCommand(bucketPos()));
+        // or if square is pressed
+        driverPad.getGamepadButton(GamepadKeys.Button.X).whenPressed(bucketPos());
 
         // --------- INTAKE --------
         // backtake/fronttake toggles
@@ -252,21 +253,20 @@ public class TeleOpps extends Robot {
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 7),
                 new SubPosReadyCommand(extension, pivot, wrist, intake, 4),
                 reverseClaw::get
-        ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
+        ));
 
         // medium
         operatorPad.getGamepadButton(GamepadKeys.Button.DPAD_UP).whenPressed(new ConditionalCommand(
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 12),
                 new SubPosReadyCommand(extension, pivot, wrist, intake, 10),
-                reverseClaw::get
-        ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
+                reverseClaw::get));
 
         // lomg
         operatorPad.getGamepadButton(GamepadKeys.Button.DPAD_RIGHT).whenPressed(new ConditionalCommand(
                 SubPosReversedCommand.newWithExtension(extension, wrist, intake, pivot, 15),
                 new SubPosReadyCommand(extension, pivot, wrist, intake, 15),
                 reverseClaw::get
-        ).alongWith(new InstantCommand(() -> setState(FSMStates.INTAKE))));
+        ));
 
         // ------- BUCKET --------
         // low bucket toggle

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/teleop/TeleOpps.java
@@ -147,9 +147,9 @@ public class TeleOpps extends Robot {
                                 new ConditionalCommand(
                                         new IntakeControlCommand(intake, IntakeConstants.backPos, -1), new IntakeControlCommand(intake, IntakeConstants.openPos, 1), reverseClaw::get),
 
-                                // eject
+                                // eject for backtake, open claw for fronttake (backtake kept for backwards compatibility)
                                 new ConditionalCommand(
-                                        new IntakeControlCommand(intake, IntakeConstants.backSinglePos, 0.5), new IntakeControlCommand(intake, IntakeConstants.singleIntakePos, -0.5), reverseClaw::get),
+                                        new IntakeControlCommand(intake, IntakeConstants.backSinglePos, 0.5), new IntakeControlCommand(intake, IntakeConstants.openPos, -0.5), reverseClaw::get),
 
                                 () -> getState() == FSMStates.INTAKE)
                 )
@@ -233,12 +233,12 @@ public class TeleOpps extends Robot {
                         new ConditionalCommand(new IntakeControlCommand(intake, IntakeConstants.backClosedPos, -1),
                                 new IntakeControlCommand(intake, IntakeConstants.closedPos, 1), reverseClaw::get))
                 .whenReleased(new IntakeSpinCommand(intake, 0));
-        // claw in all states
+        // reverse intake in all states
         operatorPad.getGamepadButton(GamepadKeys.Button.LEFT_BUMPER).whenPressed(
-                        new ConditionalCommand(new IntakeClawCommand(intake, IntakeConstants.backPos),
-                                new IntakeClawCommand(intake, IntakeConstants.openPos), reverseClaw::get))
-                .whenReleased(new ConditionalCommand(new IntakeClawCommand(intake, IntakeConstants.backClosedPos),
-                        new IntakeClawCommand(intake, IntakeConstants.closedPos), reverseClaw::get));
+                        new ConditionalCommand(new IntakeControlCommand(intake, IntakeConstants.backSinglePos, 1),
+                                new IntakeControlCommand(intake, IntakeConstants.singleIntakePos, -1), reverseClaw::get))
+                .whenReleased(new ConditionalCommand(new IntakeControlCommand(intake, IntakeConstants.backClosedPos, 0),
+                        new IntakeControlCommand(intake, IntakeConstants.closedPos, 0), reverseClaw::get));
 
         // -------- INTAKE PRESETS ---------
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/test/LEDTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/opmode/test/LEDTest.java
@@ -1,23 +1,29 @@
 package org.firstinspires.ftc.teamcode.opmode.test;
 
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.DigitalChannel;
 
 import org.firstinspires.ftc.teamcode.subsystems.LEDSubsystem;
-
+@TeleOp
 public class LEDTest extends LinearOpMode {
     LEDSubsystem ledSubsystem;
 
     @Override
     public void runOpMode() throws InterruptedException {
-        ledSubsystem = new LEDSubsystem(hardwareMap);
-
-        boolean variable = false;
-
-        while (!isStopRequested()){
-            ledSubsystem.setLightState(variable);
-            variable = !variable;
-
-            wait(1000);
+        DigitalChannel led1 = hardwareMap.digitalChannel.get("led1");
+        led1.setMode(DigitalChannel.Mode.OUTPUT);
+        DigitalChannel led2 = hardwareMap.digitalChannel.get("led2");
+        led2.setMode(DigitalChannel.Mode.OUTPUT);
+        DigitalChannel led3 = hardwareMap.digitalChannel.get("led3");
+        led3.setMode(DigitalChannel.Mode.OUTPUT);
+        DigitalChannel led4 = hardwareMap.digitalChannel.get("led4");
+        led4.setMode(DigitalChannel.Mode.OUTPUT);
+        while (!isStopRequested()) {
+            led1.setState(gamepad1.a);
+            led2.setState(gamepad1.b);
+            led3.setState(gamepad1.x);
+            led4.setState(gamepad1.y);
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/subsystems/IntakeSubsystem.java
@@ -42,7 +42,7 @@ public class IntakeSubsystem extends SubsystemBase {
     }
     public void setClawer(double value) {
         clawPos = value;
-        clawer.setPosition(clawPos);
+        clawer.setPosition(clawPos + IntakeConstants.clawOffset);
     }
 
 

--- a/TeamCode/src/main/res/xml/intothesleep.xml
+++ b/TeamCode/src/main/res/xml/intothesleep.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<Robot type="FirstInspires-FTC">
+    <LynxUsbDevice name="Control Hub Portal" serialNumber="(embedded)" parentModuleAddress="173">
+        <LynxModule name="Control Hub" port="173">
+            <goBILDA5202SeriesMotor name="frontLeft" port="0" />
+            <goBILDA5202SeriesMotor name="backRight" port="1" />
+            <goBILDA5202SeriesMotor name="backLeft" port="2" />
+            <goBILDA5202SeriesMotor name="frontRight" port="3" />
+            <ContinuousRotationServo name="intake" port="0" />
+            <Servo name="wrist" port="1" />
+            <Servo name="clawer" port="2" />
+            <Servo name="stick" port="3" />
+            <Servo name="light" port="5" />
+            <AnalogInput name="sensOrange" port="0" />
+            <AnalogInput name="clawSens2" port="2" />
+            <AnalogInput name="clawSens1" port="3" />
+            <DigitalDevice name="led1" port="0" />
+            <DigitalDevice name="led2" port="1" />
+            <DigitalDevice name="led3" port="2" />
+            <DigitalDevice name="led4" port="3" />
+            <LynxEmbeddedIMU name="imu" port="0" bus="0" />
+            <goBILDAPinpoint name="pinpoint" port="1" bus="1" />
+        </LynxModule>
+        <LynxModule name="Expansion Hub 1" port="1">
+            <goBILDA5202SeriesMotor name="slide0" port="0" />
+            <goBILDA5202SeriesMotor name="slide1" port="1" />
+            <goBILDA5202SeriesMotor name="tilt0" port="2" />
+            <goBILDA5202SeriesMotor name="tilt1" port="3" />
+            <LynxEmbeddedIMU name="imu 1" port="0" bus="0" />
+        </LynxModule>
+    </LynxUsbDevice>
+    <Webcam name="rizz" serialNumber="VendorProduct:vendor=0x1e45|product=0x8022|connection=" />
+</Robot>


### PR DESCRIPTION
# 4 Second Cycle Times as The Robot Can Fly Now
yes repo stalkers that one was for you

Changes:
- Changed operator presets to just extend the slides instead of also dropping down the claw.
- Changed driver intake functionality to accommodate this new behaviour.
- Swapped driver and operator outtake responsibilities - driver now has claw and operator has reverse.
- Added mapping from right trigger to bucket position if a sample is detected in the intake.

Need to tune:
- intakeReadyPos in IntakeConstants. Make it as close as possible to groundPos without having it hit anything.